### PR TITLE
サーバー側で作成したチャットルームが正しく表示されていない問題解消

### DIFF
--- a/client.py
+++ b/client.py
@@ -47,11 +47,12 @@ class Client:
         # ヘッダーとボディをサーバーに送信
         req = header + body
         self.tcp_socket.sendall(req)
-        print(req)
+        print(f"request: {req}")
 
         # サーバーからヘッダーとボディを受信
         res = self.tcp_socket.recv(4096)
-        print(res)
+
+        print(f"response: {res}")
 
         # ヘッダーからstateを取得
         state = res[2]

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 import socket
+import struct
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
@@ -53,12 +54,13 @@ class Server:
     def handle_tcp_conn(self, conn, client_address):
         # クライアントからのデータを受信
         header = conn.recv(32)
-        room_name_size = header[0]
-        operation = header[1]
+        room_name_size, operation, state, operation_payload_size = struct.unpack('!B B B 29s', header)
 
         body = conn.recv(4096)
-        room_name = body[:room_name_size].decode("utf-8")
-        user_name = body[room_name_size:].decode("utf-8")
+        decoded_body = body.decode("utf-8")
+
+        room_name = decoded_body[:room_name_size]
+        user_name = decoded_body[room_name_size:]
 
         # operation = 1 ... 部屋作成
         if operation == 1:


### PR DESCRIPTION
## 元々のエラー事象
https://github.com/Recursion-BackendNovice-TeamA/TeamDev-OnlineChatMessenger/issues/19#issue-1923946878


## 修正後
`部屋１`というチャットルームを作成時に、サーバーにも`部屋１`が表示されるように修正

### クライアント

![image](https://github.com/Recursion-BackendNovice-TeamA/TeamDev-OnlineChatMessenger/assets/88995036/63301782-5534-43d9-af66-9f959f037fce)


### サーバー
![image](https://github.com/Recursion-BackendNovice-TeamA/TeamDev-OnlineChatMessenger/assets/88995036/fc5d8c8d-ac89-40ac-9654-df208d707f18)

